### PR TITLE
Fix manual job

### DIFF
--- a/files/steps/generate_dataset_from_hbase.py
+++ b/files/steps/generate_dataset_from_hbase.py
@@ -274,7 +274,7 @@ def replica_metadata_refresh():
     os.system('echo "refresh_meta" | hbase shell')
 
 
-def retry_requests(retries=10, backoff=1, methods=None):
+def retry_requests(retries=10, backoff=0.2, methods=None):
     if methods is None:
         methods = ["POST"]
     retry_strategy = Retry(

--- a/files/steps/generate_dataset_from_hbase.py
+++ b/files/steps/generate_dataset_from_hbase.py
@@ -620,6 +620,9 @@ def manual_handler(args):
         "record_count": record_count,
         "max_timestamps": max_timestamps,
     }
+    args.end_time = (
+        ms_epoch_now() if args.end_time is None else args.end_time
+    )
 
     # main
     collections = get_collections(args)


### PR DESCRIPTION
Minor changes to increase the rate of retries to DKS (taking too long to fail) and ensure that end_time arg is available to the job if not provided when launched